### PR TITLE
Fix empty query parameters

### DIFF
--- a/internal/core/tool.go
+++ b/internal/core/tool.go
@@ -92,6 +92,9 @@ func (s *Server) prepareRequest(tool *config.ToolConfig, tmplCtx *template.Conte
 func processArguments(req *http.Request, tool *config.ToolConfig, args map[string]any) {
 	for _, arg := range tool.Args {
 		value := fmt.Sprint(args[arg.Name])
+		if value == "" || value == "<nil>" {
+			continue
+		}
 		switch strings.ToLower(arg.Position) {
 		case "header":
 			req.Header.Set(arg.Name, value)


### PR DESCRIPTION
## Summary
- skip empty arguments when building request params

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687bdbe253948327899442d540d69815